### PR TITLE
fixes missing `sqlite3` symbol when importing `SQLite3` (case-sensitive)

### DIFF
--- a/Sources/SQLite/Core/Connection.swift
+++ b/Sources/SQLite/Core/Connection.swift
@@ -587,7 +587,7 @@ public final class Connection {
         var flags = SQLITE_UTF8
         #if !os(Linux)
         if deterministic {
-            flags |= sqlite3.SQLITE_DETERMINISTIC
+            flags |= SQLITE_DETERMINISTIC
         }
         #endif
         sqlite3_create_function_v2(handle, function, Int32(argc), flags, unsafeBitCast(box, to: UnsafeMutableRawPointer.self), { context, argc, value in


### PR DESCRIPTION
This seems to diverge from the upstream/original code, and it makes compiling the project on it's own not work as well. `sqlite3` is only found and imported when e.g. compiling using the CocoaPods settings; otherwise, its `SQLite3`. That's case-sensitive. By removing the module name prefix, we leave figuring this out to the compiler.

Tested this in Timing using CocoaPods on a local clone of the repo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mrmage/sqlite.swift/1)
<!-- Reviewable:end -->
