### PR TITLE
[WIP] add throwing Value lookup variant

### DIFF
--- a/SQLite.xcodeproj/project.pbxproj
+++ b/SQLite.xcodeproj/project.pbxproj
@@ -108,6 +108,10 @@
 		49EB68C51F7B3CB400D89D40 /* Coding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49EB68C31F7B3CB400D89D40 /* Coding.swift */; };
 		49EB68C61F7B3CB400D89D40 /* Coding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49EB68C31F7B3CB400D89D40 /* Coding.swift */; };
 		49EB68C71F7B3CB400D89D40 /* Coding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49EB68C31F7B3CB400D89D40 /* Coding.swift */; };
+		50929FCD257F887E00BA4A28 /* RiskyValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50929FCC257F887E00BA4A28 /* RiskyValue.swift */; };
+		50929FCE257F887E00BA4A28 /* RiskyValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50929FCC257F887E00BA4A28 /* RiskyValue.swift */; };
+		50929FCF257F887E00BA4A28 /* RiskyValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50929FCC257F887E00BA4A28 /* RiskyValue.swift */; };
+		50929FD0257F887E00BA4A28 /* RiskyValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50929FCC257F887E00BA4A28 /* RiskyValue.swift */; };
 		EE247AD71C3F04ED00AE3E12 /* SQLite.h in Headers */ = {isa = PBXBuildFile; fileRef = EE247AD61C3F04ED00AE3E12 /* SQLite.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EE247ADE1C3F04ED00AE3E12 /* SQLite.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EE247AD31C3F04ED00AE3E12 /* SQLite.framework */; };
 		EE247B031C3F06E900AE3E12 /* Blob.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE247AEE1C3F06E900AE3E12 /* Blob.swift */; };
@@ -227,6 +231,7 @@
 		19A17E2695737FAB5D6086E3 /* fixtures */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = folder; path = fixtures; sourceTree = "<group>"; };
 		3D67B3E51DB2469200A4F4C6 /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = Platforms/WatchOS.platform/Developer/SDKs/WatchOS3.0.sdk/usr/lib/libsqlite3.tbd; sourceTree = DEVELOPER_DIR; };
 		49EB68C31F7B3CB400D89D40 /* Coding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coding.swift; sourceTree = "<group>"; };
+		50929FCC257F887E00BA4A28 /* RiskyValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RiskyValue.swift; sourceTree = "<group>"; };
 		A121AC451CA35C79005A31D1 /* SQLite.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SQLite.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EE247AD31C3F04ED00AE3E12 /* SQLite.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SQLite.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EE247AD61C3F04ED00AE3E12 /* SQLite.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SQLite.h; sourceTree = "<group>"; };
@@ -433,6 +438,7 @@
 				EE247AF11C3F06E900AE3E12 /* SQLiteObjc.m */,
 				EE247AF21C3F06E900AE3E12 /* Statement.swift */,
 				EE247AF31C3F06E900AE3E12 /* Value.swift */,
+				50929FCC257F887E00BA4A28 /* RiskyValue.swift */,
 				19A1710E73A46D5AC721CDA9 /* Errors.swift */,
 			);
 			path = Core;
@@ -798,6 +804,7 @@
 			files = (
 				03A65E801C6BB2FB0062603F /* CoreFunctions.swift in Sources */,
 				49EB68C61F7B3CB400D89D40 /* Coding.swift in Sources */,
+				50929FCF257F887E00BA4A28 /* RiskyValue.swift in Sources */,
 				03A65E761C6BB2E60062603F /* Blob.swift in Sources */,
 				03A65E7D1C6BB2F70062603F /* RTree.swift in Sources */,
 				03A65E791C6BB2EF0062603F /* SQLiteObjc.m in Sources */,
@@ -856,6 +863,7 @@
 			files = (
 				3D67B3F91DB246E700A4F4C6 /* SQLiteObjc.m in Sources */,
 				49EB68C71F7B3CB400D89D40 /* Coding.swift in Sources */,
+				50929FD0257F887E00BA4A28 /* RiskyValue.swift in Sources */,
 				3D67B3F71DB246D700A4F4C6 /* Foundation.swift in Sources */,
 				3D67B3F81DB246D700A4F4C6 /* Helpers.swift in Sources */,
 				3D67B3E91DB246D100A4F4C6 /* Statement.swift in Sources */,
@@ -886,6 +894,7 @@
 			files = (
 				EE247B0F1C3F06E900AE3E12 /* CoreFunctions.swift in Sources */,
 				49EB68C41F7B3CB400D89D40 /* Coding.swift in Sources */,
+				50929FCD257F887E00BA4A28 /* RiskyValue.swift in Sources */,
 				EE247B0A1C3F06E900AE3E12 /* RTree.swift in Sources */,
 				EE247B031C3F06E900AE3E12 /* Blob.swift in Sources */,
 				EE247B0B1C3F06E900AE3E12 /* Foundation.swift in Sources */,
@@ -944,6 +953,7 @@
 			files = (
 				EE247B6F1C3F3FEC00AE3E12 /* CoreFunctions.swift in Sources */,
 				49EB68C51F7B3CB400D89D40 /* Coding.swift in Sources */,
+				50929FCE257F887E00BA4A28 /* RiskyValue.swift in Sources */,
 				EE247B651C3F3FEC00AE3E12 /* Blob.swift in Sources */,
 				EE247B6C1C3F3FEC00AE3E12 /* RTree.swift in Sources */,
 				EE247B681C3F3FEC00AE3E12 /* SQLiteObjc.m in Sources */,

--- a/Sources/SQLite/Core/RiskyValue.swift
+++ b/Sources/SQLite/Core/RiskyValue.swift
@@ -6,11 +6,6 @@
 //  Copyright © 2020 Timing Software GmbH. All rights reserved.
 //
 
-public protocol RiskyValue : Expressible {
-    associatedtype ValueType = Self
-    associatedtype Datatype : Binding
-
-    var datatypeValue: Datatype { get }
+public protocol RiskyValue : AnyValue {
     static func fromDatatypeValue(_ datatypeValue: Datatype) throws -> ValueType
-    static var declaredDatatype: String { get }
 }

--- a/Sources/SQLite/Core/RiskyValue.swift
+++ b/Sources/SQLite/Core/RiskyValue.swift
@@ -1,0 +1,16 @@
+//
+//  RiskyValue.swift
+//  SQLite
+//
+//  Created by Christian Tietze on 08.12.20.
+//  Copyright © 2020 Timing Software GmbH. All rights reserved.
+//
+
+public protocol RiskyValue : Expressible {
+    associatedtype ValueType = Self
+    associatedtype Datatype : Binding
+
+    var datatypeValue: Datatype { get }
+    static func fromDatatypeValue(_ datatypeValue: Datatype) throws -> ValueType
+    static var declaredDatatype: String { get }
+}

--- a/Sources/SQLite/Core/Value.swift
+++ b/Sources/SQLite/Core/Value.swift
@@ -31,7 +31,8 @@ public protocol Binding {}
 
 public protocol Number : Binding {}
 
-public protocol Value : Expressible { // extensions cannot have inheritance clauses
+/// - See `Value`: Safe value, not throwing when trying to get a value.
+public protocol AnyValue : Expressible {
 
     associatedtype ValueType = Self
 
@@ -39,10 +40,24 @@ public protocol Value : Expressible { // extensions cannot have inheritance clau
 
     static var declaredDatatype: String { get }
 
-    static func fromDatatypeValue(_ datatypeValue: Datatype) -> ValueType
-
     var datatypeValue: Datatype { get }
 
+    static func fromDatatypeValue(_ datatypeValue: Datatype) throws -> ValueType
+}
+
+public protocol Value : AnyValue { // extensions cannot have inheritance clauses
+
+    static func fromDatatypeValue(_ datatypeValue: Datatype) -> ValueType
+
+}
+
+extension Value {
+
+    public static func fromDatatypeValue(_ datatypeValue: Datatype) throws -> ValueType {
+        // Use the non-throwing variant by default.
+        return fromDatatypeValue(datatypeValue)
+    }
+    
 }
 
 extension Double : Number, Value {

--- a/Sources/SQLite/Foundation.swift
+++ b/Sources/SQLite/Foundation.swift
@@ -68,3 +68,23 @@ public var dateFormatter: DateFormatter = {
     formatter.timeZone = TimeZone(secondsFromGMT: 0)
     return formatter
 }()
+
+extension URL : RiskyValue {
+    public struct URLRiskyValueError: Error {}
+
+    public typealias Datatype = String
+
+    public var datatypeValue: String {
+        return absoluteString
+    }
+
+    public static var declaredDatatype: String {
+        return String.declaredDatatype
+    }
+
+    public static func fromDatatypeValue(_ datatypeValue: String) throws -> URL {
+        guard let url = URL(string: datatypeValue) else { throw URLRiskyValueError() }
+        return url
+    }
+
+}

--- a/Sources/SQLite/Typed/Expression.swift
+++ b/Sources/SQLite/Typed/Expression.swift
@@ -109,9 +109,9 @@ extension ExpressionType {
 }
 
 // MARK: -
-// MARK: Value conformance
+// MARK: AnyValue conformance
 
-extension ExpressionType where UnderlyingType : Value {
+extension ExpressionType where UnderlyingType : AnyValue {
 
     public init(value: UnderlyingType) {
         self.init("?", [value.datatypeValue])
@@ -119,7 +119,7 @@ extension ExpressionType where UnderlyingType : Value {
 
 }
 
-extension ExpressionType where UnderlyingType : _OptionalType, UnderlyingType.WrappedType : Value {
+extension ExpressionType where UnderlyingType : _OptionalType, UnderlyingType.WrappedType : AnyValue {
 
     public static var null: Self {
         return self.init(value: nil)
@@ -131,7 +131,7 @@ extension ExpressionType where UnderlyingType : _OptionalType, UnderlyingType.Wr
 
 }
 
-extension Value {
+extension AnyValue {
 
     public var expression: Expression<Void> {
         return Expression(value: self).expression
@@ -139,35 +139,65 @@ extension Value {
 
 }
 
-// MARK: RiskyValue conformance
-
-extension ExpressionType where UnderlyingType : RiskyValue {
-
-    public init(value: UnderlyingType) {
-        self.init("?", [value.datatypeValue])
-    }
-
-}
-
-extension ExpressionType where UnderlyingType : _OptionalType, UnderlyingType.WrappedType : RiskyValue {
-
-    public static var null: Self {
-        return self.init(value: nil)
-    }
-
-    public init(value: UnderlyingType.WrappedType?) {
-        self.init("?", [value?.datatypeValue])
-    }
-
-}
-
-extension RiskyValue {
-
-    public var expression: Expression<Void> {
-        return Expression(value: self).expression
-    }
-
-}
+//// MARK: Value conformance
+//
+//extension ExpressionType where UnderlyingType : Value {
+//
+//    public init(value: UnderlyingType) {
+//        self.init("?", [value.datatypeValue])
+//    }
+//
+//}
+//
+//extension ExpressionType where UnderlyingType : _OptionalType, UnderlyingType.WrappedType : Value {
+//
+//    public static var null: Self {
+//        return self.init(value: nil)
+//    }
+//
+//    public init(value: UnderlyingType.WrappedType?) {
+//        self.init("?", [value?.datatypeValue])
+//    }
+//
+//}
+//
+//extension Value {
+//
+//    public var expression: Expression<Void> {
+//        return Expression(value: self).expression
+//    }
+//
+//}
+//
+//// MARK: RiskyValue conformance
+//
+//extension ExpressionType where UnderlyingType : RiskyValue {
+//
+//    public init(value: UnderlyingType) {
+//        self.init("?", [value.datatypeValue])
+//    }
+//
+//}
+//
+//extension ExpressionType where UnderlyingType : _OptionalType, UnderlyingType.WrappedType : RiskyValue {
+//
+//    public static var null: Self {
+//        return self.init(value: nil)
+//    }
+//
+//    public init(value: UnderlyingType.WrappedType?) {
+//        self.init("?", [value?.datatypeValue])
+//    }
+//
+//}
+//
+//extension RiskyValue {
+//
+//    public var expression: Expression<Void> {
+//        return Expression(value: self).expression
+//    }
+//
+//}
 
 // MARK: -
 

--- a/Sources/SQLite/Typed/Expression.swift
+++ b/Sources/SQLite/Typed/Expression.swift
@@ -108,6 +108,9 @@ extension ExpressionType {
 
 }
 
+// MARK: -
+// MARK: Value conformance
+
 extension ExpressionType where UnderlyingType : Value {
 
     public init(value: UnderlyingType) {
@@ -135,6 +138,38 @@ extension Value {
     }
 
 }
+
+// MARK: RiskyValue conformance
+
+extension ExpressionType where UnderlyingType : RiskyValue {
+
+    public init(value: UnderlyingType) {
+        self.init("?", [value.datatypeValue])
+    }
+
+}
+
+extension ExpressionType where UnderlyingType : _OptionalType, UnderlyingType.WrappedType : RiskyValue {
+
+    public static var null: Self {
+        return self.init(value: nil)
+    }
+
+    public init(value: UnderlyingType.WrappedType?) {
+        self.init("?", [value?.datatypeValue])
+    }
+
+}
+
+extension RiskyValue {
+
+    public var expression: Expression<Void> {
+        return Expression(value: self).expression
+    }
+
+}
+
+// MARK: -
 
 public let rowid = Expression<Int64>("ROWID")
 

--- a/Sources/SQLite/Typed/Operators.swift
+++ b/Sources/SQLite/Typed/Operators.swift
@@ -83,465 +83,465 @@ public func +(lhs: String, rhs: Expression<String?>) -> Expression<String?> {
 
 // MARK: -
 
-public func +<V : Value>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<V> where V.Datatype : Number {
+public func +<V : AnyValue>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<V> where V.Datatype : Number {
     return Operator.plus.infix(lhs, rhs)
 }
-public func +<V : Value>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype : Number {
+public func +<V : AnyValue>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype : Number {
     return Operator.plus.infix(lhs, rhs)
 }
-public func +<V : Value>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<V?> where V.Datatype : Number {
+public func +<V : AnyValue>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<V?> where V.Datatype : Number {
     return Operator.plus.infix(lhs, rhs)
 }
-public func +<V : Value>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype : Number {
+public func +<V : AnyValue>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype : Number {
     return Operator.plus.infix(lhs, rhs)
 }
-public func +<V : Value>(lhs: Expression<V>, rhs: V) -> Expression<V> where V.Datatype : Number {
+public func +<V : AnyValue>(lhs: Expression<V>, rhs: V) -> Expression<V> where V.Datatype : Number {
     return Operator.plus.infix(lhs, rhs)
 }
-public func +<V : Value>(lhs: Expression<V?>, rhs: V) -> Expression<V?> where V.Datatype : Number {
+public func +<V : AnyValue>(lhs: Expression<V?>, rhs: V) -> Expression<V?> where V.Datatype : Number {
     return Operator.plus.infix(lhs, rhs)
 }
-public func +<V : Value>(lhs: V, rhs: Expression<V>) -> Expression<V> where V.Datatype : Number {
+public func +<V : AnyValue>(lhs: V, rhs: Expression<V>) -> Expression<V> where V.Datatype : Number {
     return Operator.plus.infix(lhs, rhs)
 }
-public func +<V: Value>(lhs: V, rhs: Expression<V?>) -> Expression<V?> where V.Datatype : Number {
+public func +<V: AnyValue>(lhs: V, rhs: Expression<V?>) -> Expression<V?> where V.Datatype : Number {
     return Operator.plus.infix(lhs, rhs)
 }
 
-public func -<V : Value>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<V> where V.Datatype : Number {
+public func -<V : AnyValue>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<V> where V.Datatype : Number {
     return Operator.minus.infix(lhs, rhs)
 }
-public func -<V : Value>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype : Number {
+public func -<V : AnyValue>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype : Number {
     return Operator.minus.infix(lhs, rhs)
 }
-public func -<V : Value>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<V?> where V.Datatype : Number {
+public func -<V : AnyValue>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<V?> where V.Datatype : Number {
     return Operator.minus.infix(lhs, rhs)
 }
-public func -<V : Value>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype : Number {
+public func -<V : AnyValue>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype : Number {
     return Operator.minus.infix(lhs, rhs)
 }
-public func -<V : Value>(lhs: Expression<V>, rhs: V) -> Expression<V> where V.Datatype : Number {
+public func -<V : AnyValue>(lhs: Expression<V>, rhs: V) -> Expression<V> where V.Datatype : Number {
     return Operator.minus.infix(lhs, rhs)
 }
-public func -<V : Value>(lhs: Expression<V?>, rhs: V) -> Expression<V?> where V.Datatype : Number {
+public func -<V : AnyValue>(lhs: Expression<V?>, rhs: V) -> Expression<V?> where V.Datatype : Number {
     return Operator.minus.infix(lhs, rhs)
 }
-public func -<V : Value>(lhs: V, rhs: Expression<V>) -> Expression<V> where V.Datatype : Number {
+public func -<V : AnyValue>(lhs: V, rhs: Expression<V>) -> Expression<V> where V.Datatype : Number {
     return Operator.minus.infix(lhs, rhs)
 }
-public func -<V: Value>(lhs: V, rhs: Expression<V?>) -> Expression<V?> where V.Datatype : Number {
+public func -<V: AnyValue>(lhs: V, rhs: Expression<V?>) -> Expression<V?> where V.Datatype : Number {
     return Operator.minus.infix(lhs, rhs)
 }
 
-public func *<V : Value>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<V> where V.Datatype : Number {
+public func *<V : AnyValue>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<V> where V.Datatype : Number {
     return Operator.mul.infix(lhs, rhs)
 }
-public func *<V : Value>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype : Number {
+public func *<V : AnyValue>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype : Number {
     return Operator.mul.infix(lhs, rhs)
 }
-public func *<V : Value>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<V?> where V.Datatype : Number {
+public func *<V : AnyValue>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<V?> where V.Datatype : Number {
     return Operator.mul.infix(lhs, rhs)
 }
-public func *<V : Value>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype : Number {
+public func *<V : AnyValue>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype : Number {
     return Operator.mul.infix(lhs, rhs)
 }
-public func *<V : Value>(lhs: Expression<V>, rhs: V) -> Expression<V> where V.Datatype : Number {
+public func *<V : AnyValue>(lhs: Expression<V>, rhs: V) -> Expression<V> where V.Datatype : Number {
     return Operator.mul.infix(lhs, rhs)
 }
-public func *<V : Value>(lhs: Expression<V?>, rhs: V) -> Expression<V?> where V.Datatype : Number {
+public func *<V : AnyValue>(lhs: Expression<V?>, rhs: V) -> Expression<V?> where V.Datatype : Number {
     return Operator.mul.infix(lhs, rhs)
 }
-public func *<V : Value>(lhs: V, rhs: Expression<V>) -> Expression<V> where V.Datatype : Number {
+public func *<V : AnyValue>(lhs: V, rhs: Expression<V>) -> Expression<V> where V.Datatype : Number {
     return Operator.mul.infix(lhs, rhs)
 }
-public func *<V: Value>(lhs: V, rhs: Expression<V?>) -> Expression<V?> where V.Datatype : Number {
+public func *<V: AnyValue>(lhs: V, rhs: Expression<V?>) -> Expression<V?> where V.Datatype : Number {
     return Operator.mul.infix(lhs, rhs)
 }
 
-public func /<V : Value>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<V> where V.Datatype : Number {
+public func /<V : AnyValue>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<V> where V.Datatype : Number {
     return Operator.div.infix(lhs, rhs)
 }
-public func /<V : Value>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype : Number {
+public func /<V : AnyValue>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype : Number {
     return Operator.div.infix(lhs, rhs)
 }
-public func /<V : Value>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<V?> where V.Datatype : Number {
+public func /<V : AnyValue>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<V?> where V.Datatype : Number {
     return Operator.div.infix(lhs, rhs)
 }
-public func /<V : Value>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype : Number {
+public func /<V : AnyValue>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype : Number {
     return Operator.div.infix(lhs, rhs)
 }
-public func /<V : Value>(lhs: Expression<V>, rhs: V) -> Expression<V> where V.Datatype : Number {
+public func /<V : AnyValue>(lhs: Expression<V>, rhs: V) -> Expression<V> where V.Datatype : Number {
     return Operator.div.infix(lhs, rhs)
 }
-public func /<V : Value>(lhs: Expression<V?>, rhs: V) -> Expression<V?> where V.Datatype : Number {
+public func /<V : AnyValue>(lhs: Expression<V?>, rhs: V) -> Expression<V?> where V.Datatype : Number {
     return Operator.div.infix(lhs, rhs)
 }
-public func /<V : Value>(lhs: V, rhs: Expression<V>) -> Expression<V> where V.Datatype : Number {
+public func /<V : AnyValue>(lhs: V, rhs: Expression<V>) -> Expression<V> where V.Datatype : Number {
     return Operator.div.infix(lhs, rhs)
 }
-public func /<V: Value>(lhs: V, rhs: Expression<V?>) -> Expression<V?> where V.Datatype : Number {
+public func /<V: AnyValue>(lhs: V, rhs: Expression<V?>) -> Expression<V?> where V.Datatype : Number {
     return Operator.div.infix(lhs, rhs)
 }
 
-public prefix func -<V : Value>(rhs: Expression<V>) -> Expression<V> where V.Datatype : Number {
+public prefix func -<V : AnyValue>(rhs: Expression<V>) -> Expression<V> where V.Datatype : Number {
     return Operator.minus.wrap(rhs)
 }
-public prefix func -<V : Value>(rhs: Expression<V?>) -> Expression<V?> where V.Datatype : Number {
+public prefix func -<V : AnyValue>(rhs: Expression<V?>) -> Expression<V?> where V.Datatype : Number {
     return Operator.minus.wrap(rhs)
 }
 
 // MARK: -
 
-public func %<V : Value>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<V> where V.Datatype == Int64 {
+public func %<V : AnyValue>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<V> where V.Datatype == Int64 {
     return Operator.mod.infix(lhs, rhs)
 }
-public func %<V : Value>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
+public func %<V : AnyValue>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
     return Operator.mod.infix(lhs, rhs)
 }
-public func %<V : Value>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<V?> where V.Datatype == Int64 {
+public func %<V : AnyValue>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<V?> where V.Datatype == Int64 {
     return Operator.mod.infix(lhs, rhs)
 }
-public func %<V : Value>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
+public func %<V : AnyValue>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
     return Operator.mod.infix(lhs, rhs)
 }
-public func %<V : Value>(lhs: Expression<V>, rhs: V) -> Expression<V> where V.Datatype == Int64 {
+public func %<V : AnyValue>(lhs: Expression<V>, rhs: V) -> Expression<V> where V.Datatype == Int64 {
     return Operator.mod.infix(lhs, rhs)
 }
-public func %<V : Value>(lhs: Expression<V?>, rhs: V) -> Expression<V?> where V.Datatype == Int64 {
+public func %<V : AnyValue>(lhs: Expression<V?>, rhs: V) -> Expression<V?> where V.Datatype == Int64 {
     return Operator.mod.infix(lhs, rhs)
 }
-public func %<V : Value>(lhs: V, rhs: Expression<V>) -> Expression<V> where V.Datatype == Int64 {
+public func %<V : AnyValue>(lhs: V, rhs: Expression<V>) -> Expression<V> where V.Datatype == Int64 {
     return Operator.mod.infix(lhs, rhs)
 }
-public func %<V : Value>(lhs: V, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
+public func %<V : AnyValue>(lhs: V, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
     return Operator.mod.infix(lhs, rhs)
 }
 
-public func <<<V : Value>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<V> where V.Datatype == Int64 {
+public func <<<V : AnyValue>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<V> where V.Datatype == Int64 {
     return Operator.bitwiseLeft.infix(lhs, rhs)
 }
-public func <<<V : Value>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
+public func <<<V : AnyValue>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
     return Operator.bitwiseLeft.infix(lhs, rhs)
 }
-public func <<<V : Value>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<V?> where V.Datatype == Int64 {
+public func <<<V : AnyValue>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<V?> where V.Datatype == Int64 {
     return Operator.bitwiseLeft.infix(lhs, rhs)
 }
-public func <<<V : Value>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
+public func <<<V : AnyValue>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
     return Operator.bitwiseLeft.infix(lhs, rhs)
 }
-public func <<<V : Value>(lhs: Expression<V>, rhs: V) -> Expression<V> where V.Datatype == Int64 {
+public func <<<V : AnyValue>(lhs: Expression<V>, rhs: V) -> Expression<V> where V.Datatype == Int64 {
     return Operator.bitwiseLeft.infix(lhs, rhs)
 }
-public func <<<V : Value>(lhs: Expression<V?>, rhs: V) -> Expression<V?> where V.Datatype == Int64 {
+public func <<<V : AnyValue>(lhs: Expression<V?>, rhs: V) -> Expression<V?> where V.Datatype == Int64 {
     return Operator.bitwiseLeft.infix(lhs, rhs)
 }
-public func <<<V : Value>(lhs: V, rhs: Expression<V>) -> Expression<V> where V.Datatype == Int64 {
+public func <<<V : AnyValue>(lhs: V, rhs: Expression<V>) -> Expression<V> where V.Datatype == Int64 {
     return Operator.bitwiseLeft.infix(lhs, rhs)
 }
-public func <<<V : Value>(lhs: V, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
+public func <<<V : AnyValue>(lhs: V, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
     return Operator.bitwiseLeft.infix(lhs, rhs)
 }
 
-public func >><V : Value>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<V> where V.Datatype == Int64 {
+public func >><V : AnyValue>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<V> where V.Datatype == Int64 {
     return Operator.bitwiseRight.infix(lhs, rhs)
 }
-public func >><V : Value>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
+public func >><V : AnyValue>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
     return Operator.bitwiseRight.infix(lhs, rhs)
 }
-public func >><V : Value>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<V?> where V.Datatype == Int64 {
+public func >><V : AnyValue>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<V?> where V.Datatype == Int64 {
     return Operator.bitwiseRight.infix(lhs, rhs)
 }
-public func >><V : Value>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
+public func >><V : AnyValue>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
     return Operator.bitwiseRight.infix(lhs, rhs)
 }
-public func >><V : Value>(lhs: Expression<V>, rhs: V) -> Expression<V> where V.Datatype == Int64 {
+public func >><V : AnyValue>(lhs: Expression<V>, rhs: V) -> Expression<V> where V.Datatype == Int64 {
     return Operator.bitwiseRight.infix(lhs, rhs)
 }
-public func >><V : Value>(lhs: Expression<V?>, rhs: V) -> Expression<V?> where V.Datatype == Int64 {
+public func >><V : AnyValue>(lhs: Expression<V?>, rhs: V) -> Expression<V?> where V.Datatype == Int64 {
     return Operator.bitwiseRight.infix(lhs, rhs)
 }
-public func >><V : Value>(lhs: V, rhs: Expression<V>) -> Expression<V> where V.Datatype == Int64 {
+public func >><V : AnyValue>(lhs: V, rhs: Expression<V>) -> Expression<V> where V.Datatype == Int64 {
     return Operator.bitwiseRight.infix(lhs, rhs)
 }
-public func >><V : Value>(lhs: V, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
+public func >><V : AnyValue>(lhs: V, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
     return Operator.bitwiseRight.infix(lhs, rhs)
 }
 
-public func &<V : Value>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<V> where V.Datatype == Int64 {
+public func &<V : AnyValue>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<V> where V.Datatype == Int64 {
     return Operator.bitwiseAnd.infix(lhs, rhs)
 }
-public func &<V : Value>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
+public func &<V : AnyValue>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
     return Operator.bitwiseAnd.infix(lhs, rhs)
 }
-public func &<V : Value>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<V?> where V.Datatype == Int64 {
+public func &<V : AnyValue>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<V?> where V.Datatype == Int64 {
     return Operator.bitwiseAnd.infix(lhs, rhs)
 }
-public func &<V : Value>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
+public func &<V : AnyValue>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
     return Operator.bitwiseAnd.infix(lhs, rhs)
 }
-public func &<V : Value>(lhs: Expression<V>, rhs: V) -> Expression<V> where V.Datatype == Int64 {
+public func &<V : AnyValue>(lhs: Expression<V>, rhs: V) -> Expression<V> where V.Datatype == Int64 {
     return Operator.bitwiseAnd.infix(lhs, rhs)
 }
-public func &<V : Value>(lhs: Expression<V?>, rhs: V) -> Expression<V?> where V.Datatype == Int64 {
+public func &<V : AnyValue>(lhs: Expression<V?>, rhs: V) -> Expression<V?> where V.Datatype == Int64 {
     return Operator.bitwiseAnd.infix(lhs, rhs)
 }
-public func &<V : Value>(lhs: V, rhs: Expression<V>) -> Expression<V> where V.Datatype == Int64 {
+public func &<V : AnyValue>(lhs: V, rhs: Expression<V>) -> Expression<V> where V.Datatype == Int64 {
     return Operator.bitwiseAnd.infix(lhs, rhs)
 }
-public func &<V : Value>(lhs: V, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
+public func &<V : AnyValue>(lhs: V, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
     return Operator.bitwiseAnd.infix(lhs, rhs)
 }
 
-public func |<V : Value>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<V> where V.Datatype == Int64 {
+public func |<V : AnyValue>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<V> where V.Datatype == Int64 {
     return Operator.bitwiseOr.infix(lhs, rhs)
 }
-public func |<V : Value>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
+public func |<V : AnyValue>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
     return Operator.bitwiseOr.infix(lhs, rhs)
 }
-public func |<V : Value>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<V?> where V.Datatype == Int64 {
+public func |<V : AnyValue>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<V?> where V.Datatype == Int64 {
     return Operator.bitwiseOr.infix(lhs, rhs)
 }
-public func |<V : Value>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
+public func |<V : AnyValue>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
     return Operator.bitwiseOr.infix(lhs, rhs)
 }
-public func |<V : Value>(lhs: Expression<V>, rhs: V) -> Expression<V> where V.Datatype == Int64 {
+public func |<V : AnyValue>(lhs: Expression<V>, rhs: V) -> Expression<V> where V.Datatype == Int64 {
     return Operator.bitwiseOr.infix(lhs, rhs)
 }
-public func |<V : Value>(lhs: Expression<V?>, rhs: V) -> Expression<V?> where V.Datatype == Int64 {
+public func |<V : AnyValue>(lhs: Expression<V?>, rhs: V) -> Expression<V?> where V.Datatype == Int64 {
     return Operator.bitwiseOr.infix(lhs, rhs)
 }
-public func |<V : Value>(lhs: V, rhs: Expression<V>) -> Expression<V> where V.Datatype == Int64 {
+public func |<V : AnyValue>(lhs: V, rhs: Expression<V>) -> Expression<V> where V.Datatype == Int64 {
     return Operator.bitwiseOr.infix(lhs, rhs)
 }
-public func |<V : Value>(lhs: V, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
+public func |<V : AnyValue>(lhs: V, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
     return Operator.bitwiseOr.infix(lhs, rhs)
 }
 
-public func ^<V : Value>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<V> where V.Datatype == Int64 {
+public func ^<V : AnyValue>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<V> where V.Datatype == Int64 {
     return (~(lhs & rhs)) & (lhs | rhs)
 }
-public func ^<V : Value>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
+public func ^<V : AnyValue>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
     return (~(lhs & rhs)) & (lhs | rhs)
 }
-public func ^<V : Value>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<V?> where V.Datatype == Int64 {
+public func ^<V : AnyValue>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<V?> where V.Datatype == Int64 {
     return (~(lhs & rhs)) & (lhs | rhs)
 }
-public func ^<V : Value>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
+public func ^<V : AnyValue>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
     return (~(lhs & rhs)) & (lhs | rhs)
 }
-public func ^<V : Value>(lhs: Expression<V>, rhs: V) -> Expression<V> where V.Datatype == Int64 {
+public func ^<V : AnyValue>(lhs: Expression<V>, rhs: V) -> Expression<V> where V.Datatype == Int64 {
     return (~(lhs & rhs)) & (lhs | rhs)
 }
-public func ^<V : Value>(lhs: Expression<V?>, rhs: V) -> Expression<V?> where V.Datatype == Int64 {
+public func ^<V : AnyValue>(lhs: Expression<V?>, rhs: V) -> Expression<V?> where V.Datatype == Int64 {
     return (~(lhs & rhs)) & (lhs | rhs)
 }
-public func ^<V : Value>(lhs: V, rhs: Expression<V>) -> Expression<V> where V.Datatype == Int64 {
+public func ^<V : AnyValue>(lhs: V, rhs: Expression<V>) -> Expression<V> where V.Datatype == Int64 {
     return (~(lhs & rhs)) & (lhs | rhs)
 }
-public func ^<V : Value>(lhs: V, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
+public func ^<V : AnyValue>(lhs: V, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
     return (~(lhs & rhs)) & (lhs | rhs)
 }
 
-public prefix func ~<V : Value>(rhs: Expression<V>) -> Expression<V> where V.Datatype == Int64 {
+public prefix func ~<V : AnyValue>(rhs: Expression<V>) -> Expression<V> where V.Datatype == Int64 {
     return Operator.bitwiseXor.wrap(rhs)
 }
-public prefix func ~<V : Value>(rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
+public prefix func ~<V : AnyValue>(rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
     return Operator.bitwiseXor.wrap(rhs)
 }
 
 // MARK: -
 
-public func ==<V : Value>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Equatable {
+public func ==<V : AnyValue>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Equatable {
     return Operator.eq.infix(lhs, rhs)
 }
-public func ==<V : Value>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Equatable {
+public func ==<V : AnyValue>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Equatable {
     return Operator.eq.infix(lhs, rhs)
 }
-public func ==<V : Value>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Equatable {
+public func ==<V : AnyValue>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Equatable {
     return Operator.eq.infix(lhs, rhs)
 }
-public func ==<V : Value>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Equatable {
+public func ==<V : AnyValue>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Equatable {
     return Operator.eq.infix(lhs, rhs)
 }
-public func ==<V : Value>(lhs: Expression<V>, rhs: V) -> Expression<Bool> where V.Datatype : Equatable {
+public func ==<V : AnyValue>(lhs: Expression<V>, rhs: V) -> Expression<Bool> where V.Datatype : Equatable {
     return Operator.eq.infix(lhs, rhs)
 }
-public func ==<V : Value>(lhs: Expression<V?>, rhs: V?) -> Expression<Bool> where V.Datatype : Equatable {
+public func ==<V : AnyValue>(lhs: Expression<V?>, rhs: V?) -> Expression<Bool> where V.Datatype : Equatable {
     guard let rhs = rhs else { return "IS".infix(lhs, Expression<V?>(value: nil)) }
     return Operator.eq.infix(lhs, rhs)
 }
-public func ==<V : Value>(lhs: V, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Equatable {
+public func ==<V : AnyValue>(lhs: V, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Equatable {
     return Operator.eq.infix(lhs, rhs)
 }
-public func ==<V : Value>(lhs: V?, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Equatable {
+public func ==<V : AnyValue>(lhs: V?, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Equatable {
     guard let lhs = lhs else { return "IS".infix(Expression<V?>(value: nil), rhs) }
     return Operator.eq.infix(lhs, rhs)
 }
 
-public func !=<V : Value>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Equatable {
+public func !=<V : AnyValue>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Equatable {
     return Operator.neq.infix(lhs, rhs)
 }
-public func !=<V : Value>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Equatable {
+public func !=<V : AnyValue>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Equatable {
     return Operator.neq.infix(lhs, rhs)
 }
-public func !=<V : Value>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Equatable {
+public func !=<V : AnyValue>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Equatable {
     return Operator.neq.infix(lhs, rhs)
 }
-public func !=<V : Value>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Equatable {
+public func !=<V : AnyValue>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Equatable {
     return Operator.neq.infix(lhs, rhs)
 }
-public func !=<V : Value>(lhs: Expression<V>, rhs: V) -> Expression<Bool> where V.Datatype : Equatable {
+public func !=<V : AnyValue>(lhs: Expression<V>, rhs: V) -> Expression<Bool> where V.Datatype : Equatable {
     return Operator.neq.infix(lhs, rhs)
 }
-public func !=<V : Value>(lhs: Expression<V?>, rhs: V?) -> Expression<Bool> where V.Datatype : Equatable {
+public func !=<V : AnyValue>(lhs: Expression<V?>, rhs: V?) -> Expression<Bool> where V.Datatype : Equatable {
     guard let rhs = rhs else { return "IS NOT".infix(lhs, Expression<V?>(value: nil)) }
     return Operator.neq.infix(lhs, rhs)
 }
-public func !=<V : Value>(lhs: V, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Equatable {
+public func !=<V : AnyValue>(lhs: V, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Equatable {
     return Operator.neq.infix(lhs, rhs)
 }
-public func !=<V : Value>(lhs: V?, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Equatable {
+public func !=<V : AnyValue>(lhs: V?, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Equatable {
     guard let lhs = lhs else { return "IS NOT".infix(Expression<V?>(value: nil), rhs) }
     return Operator.neq.infix(lhs, rhs)
 }
 
-public func ><V : Value>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable {
+public func ><V : AnyValue>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable {
     return Operator.gt.infix(lhs, rhs)
 }
-public func ><V : Value>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Comparable {
+public func ><V : AnyValue>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Comparable {
     return Operator.gt.infix(lhs, rhs)
 }
-public func ><V : Value>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable {
+public func ><V : AnyValue>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable {
     return Operator.gt.infix(lhs, rhs)
 }
-public func ><V : Value>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Comparable {
+public func ><V : AnyValue>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Comparable {
     return Operator.gt.infix(lhs, rhs)
 }
-public func ><V : Value>(lhs: Expression<V>, rhs: V) -> Expression<Bool> where V.Datatype : Comparable {
+public func ><V : AnyValue>(lhs: Expression<V>, rhs: V) -> Expression<Bool> where V.Datatype : Comparable {
     return Operator.gt.infix(lhs, rhs)
 }
-public func ><V : Value>(lhs: Expression<V?>, rhs: V) -> Expression<Bool> where V.Datatype : Comparable {
+public func ><V : AnyValue>(lhs: Expression<V?>, rhs: V) -> Expression<Bool> where V.Datatype : Comparable {
     return Operator.gt.infix(lhs, rhs)
 }
-public func ><V : Value>(lhs: V, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable {
+public func ><V : AnyValue>(lhs: V, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable {
     return Operator.gt.infix(lhs, rhs)
 }
-public func ><V : Value>(lhs: V, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Comparable {
+public func ><V : AnyValue>(lhs: V, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Comparable {
     return Operator.gt.infix(lhs, rhs)
 }
 
-public func >=<V : Value>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable {
+public func >=<V : AnyValue>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable {
     return Operator.gte.infix(lhs, rhs)
 }
-public func >=<V : Value>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Comparable {
+public func >=<V : AnyValue>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Comparable {
     return Operator.gte.infix(lhs, rhs)
 }
-public func >=<V : Value>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable {
+public func >=<V : AnyValue>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable {
     return Operator.gte.infix(lhs, rhs)
 }
-public func >=<V : Value>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Comparable {
+public func >=<V : AnyValue>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Comparable {
     return Operator.gte.infix(lhs, rhs)
 }
-public func >=<V : Value>(lhs: Expression<V>, rhs: V) -> Expression<Bool> where V.Datatype : Comparable {
+public func >=<V : AnyValue>(lhs: Expression<V>, rhs: V) -> Expression<Bool> where V.Datatype : Comparable {
     return Operator.gte.infix(lhs, rhs)
 }
-public func >=<V : Value>(lhs: Expression<V?>, rhs: V) -> Expression<Bool> where V.Datatype : Comparable {
+public func >=<V : AnyValue>(lhs: Expression<V?>, rhs: V) -> Expression<Bool> where V.Datatype : Comparable {
     return Operator.gte.infix(lhs, rhs)
 }
-public func >=<V : Value>(lhs: V, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable {
+public func >=<V : AnyValue>(lhs: V, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable {
     return Operator.gte.infix(lhs, rhs)
 }
-public func >=<V : Value>(lhs: V, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Comparable {
+public func >=<V : AnyValue>(lhs: V, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Comparable {
     return Operator.gte.infix(lhs, rhs)
 }
 
-public func <<V : Value>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable {
+public func <<V : AnyValue>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable {
     return Operator.lt.infix(lhs, rhs)
 }
-public func <<V : Value>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Comparable {
+public func <<V : AnyValue>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Comparable {
     return Operator.lt.infix(lhs, rhs)
 }
-public func <<V : Value>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable {
+public func <<V : AnyValue>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable {
     return Operator.lt.infix(lhs, rhs)
 }
-public func <<V : Value>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Comparable {
+public func <<V : AnyValue>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Comparable {
     return Operator.lt.infix(lhs, rhs)
 }
-public func <<V : Value>(lhs: Expression<V>, rhs: V) -> Expression<Bool> where V.Datatype : Comparable {
+public func <<V : AnyValue>(lhs: Expression<V>, rhs: V) -> Expression<Bool> where V.Datatype : Comparable {
     return Operator.lt.infix(lhs, rhs)
 }
-public func <<V : Value>(lhs: Expression<V?>, rhs: V) -> Expression<Bool> where V.Datatype : Comparable {
+public func <<V : AnyValue>(lhs: Expression<V?>, rhs: V) -> Expression<Bool> where V.Datatype : Comparable {
     return Operator.lt.infix(lhs, rhs)
 }
-public func <<V : Value>(lhs: V, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable {
+public func <<V : AnyValue>(lhs: V, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable {
     return Operator.lt.infix(lhs, rhs)
 }
-public func <<V : Value>(lhs: V, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Comparable {
+public func <<V : AnyValue>(lhs: V, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Comparable {
     return Operator.lt.infix(lhs, rhs)
 }
 
-public func <=<V : Value>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable {
+public func <=<V : AnyValue>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable {
     return Operator.lte.infix(lhs, rhs)
 }
-public func <=<V : Value>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Comparable {
+public func <=<V : AnyValue>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Comparable {
     return Operator.lte.infix(lhs, rhs)
 }
-public func <=<V : Value>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable {
+public func <=<V : AnyValue>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable {
     return Operator.lte.infix(lhs, rhs)
 }
-public func <=<V : Value>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Comparable {
+public func <=<V : AnyValue>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Comparable {
     return Operator.lte.infix(lhs, rhs)
 }
-public func <=<V : Value>(lhs: Expression<V>, rhs: V) -> Expression<Bool> where V.Datatype : Comparable {
+public func <=<V : AnyValue>(lhs: Expression<V>, rhs: V) -> Expression<Bool> where V.Datatype : Comparable {
     return Operator.lte.infix(lhs, rhs)
 }
-public func <=<V : Value>(lhs: Expression<V?>, rhs: V) -> Expression<Bool> where V.Datatype : Comparable {
+public func <=<V : AnyValue>(lhs: Expression<V?>, rhs: V) -> Expression<Bool> where V.Datatype : Comparable {
     return Operator.lte.infix(lhs, rhs)
 }
-public func <=<V : Value>(lhs: V, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable {
+public func <=<V : AnyValue>(lhs: V, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable {
     return Operator.lte.infix(lhs, rhs)
 }
-public func <=<V : Value>(lhs: V, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Comparable {
+public func <=<V : AnyValue>(lhs: V, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Comparable {
     return Operator.lte.infix(lhs, rhs)
 }
 
-public func ~=<V : Value>(lhs: ClosedRange<V>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable & Value {
+public func ~=<V : AnyValue>(lhs: ClosedRange<V>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable & Value {
     return Expression("\(rhs.template) BETWEEN ? AND ?", rhs.bindings + [lhs.lowerBound.datatypeValue, lhs.upperBound.datatypeValue])
 }
 
-public func ~=<V : Value>(lhs: ClosedRange<V>, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Comparable & Value {
+public func ~=<V : AnyValue>(lhs: ClosedRange<V>, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Comparable & Value {
     return Expression("\(rhs.template) BETWEEN ? AND ?", rhs.bindings + [lhs.lowerBound.datatypeValue, lhs.upperBound.datatypeValue])
 }
 
-public func ~=<V : Value>(lhs: Range<V>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable & Value {
+public func ~=<V : AnyValue>(lhs: Range<V>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable & Value {
     return Expression("\(rhs.template) >= ? AND \(rhs.template) < ?", rhs.bindings + [lhs.lowerBound.datatypeValue] + rhs.bindings + [lhs.upperBound.datatypeValue])
 }
 
-public func ~=<V : Value>(lhs: Range<V>, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Comparable & Value {
+public func ~=<V : AnyValue>(lhs: Range<V>, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Comparable & Value {
     return Expression("\(rhs.template) >= ? AND \(rhs.template) < ?", rhs.bindings + [lhs.lowerBound.datatypeValue] + rhs.bindings + [lhs.upperBound.datatypeValue])
 }
 
-public func ~=<V : Value>(lhs: PartialRangeThrough<V>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable & Value {
+public func ~=<V : AnyValue>(lhs: PartialRangeThrough<V>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable & Value {
     return Expression("\(rhs.template) <= ?", rhs.bindings + [lhs.upperBound.datatypeValue])
 }
 
-public func ~=<V : Value>(lhs: PartialRangeThrough<V>, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Comparable & Value {
+public func ~=<V : AnyValue>(lhs: PartialRangeThrough<V>, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Comparable & Value {
     return Expression("\(rhs.template) <= ?", rhs.bindings + [lhs.upperBound.datatypeValue])
 }
 
-public func ~=<V : Value>(lhs: PartialRangeUpTo<V>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable & Value {
+public func ~=<V : AnyValue>(lhs: PartialRangeUpTo<V>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable & Value {
     return Expression("\(rhs.template) < ?", rhs.bindings + [lhs.upperBound.datatypeValue])
 }
 
-public func ~=<V : Value>(lhs: PartialRangeUpTo<V>, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Comparable & Value {
+public func ~=<V : AnyValue>(lhs: PartialRangeUpTo<V>, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Comparable & Value {
     return Expression("\(rhs.template) < ?", rhs.bindings + [lhs.upperBound.datatypeValue])
 }
 
-public func ~=<V : Value>(lhs: PartialRangeFrom<V>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable & Value {
+public func ~=<V : AnyValue>(lhs: PartialRangeFrom<V>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable & AnyValue {
     return Expression("\(rhs.template) >= ?", rhs.bindings + [lhs.lowerBound.datatypeValue])
 }
 
-public func ~=<V : Value>(lhs: PartialRangeFrom<V>, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Comparable & Value {
+public func ~=<V : AnyValue>(lhs: PartialRangeFrom<V>, rhs: Expression<V?>) -> Expression<Bool> where V.Datatype : Comparable & AnyValue {
     return Expression("\(rhs.template) >= ?", rhs.bindings + [lhs.lowerBound.datatypeValue])
 }
 

--- a/Sources/SQLite/Typed/Query.swift
+++ b/Sources/SQLite/Typed/Query.swift
@@ -1117,7 +1117,7 @@ public struct Row {
         return try! get(column)
     }
 
-    public func get<V: RiskyValue>(_ column: Expression<V>) throws -> V {
+    public func get<V: AnyValue>(_ column: Expression<V>) throws -> V {
         if let value = try get(Expression<V?>(column)) {
             return value
         } else {
@@ -1125,7 +1125,7 @@ public struct Row {
         }
     }
 
-    public func get<V: RiskyValue>(_ column: Expression<V?>) throws -> V? {
+    public func get<V: AnyValue>(_ column: Expression<V?>) throws -> V? {
         func valueAtIndex(_ idx: Int) throws -> V? {
             guard let value = values[idx] as? V.Datatype else { return nil }
             return try V.fromDatatypeValue(value) as? V

--- a/Sources/SQLite/Typed/Setter.swift
+++ b/Sources/SQLite/Typed/Setter.swift
@@ -35,52 +35,27 @@ public struct Setter {
     let column: Expressible
     let value: Expressible
 
-    fileprivate init<V : Value>(column: Expression<V>, value: Expression<V>) {
+    fileprivate init<V : AnyValue>(column: Expression<V>, value: Expression<V>) {
         self.column = column
         self.value = value
     }
 
-    fileprivate init<V : Value>(column: Expression<V>, value: V) {
+    fileprivate init<V : AnyValue>(column: Expression<V>, value: V) {
         self.column = column
         self.value = value
     }
 
-    fileprivate init<V : Value>(column: Expression<V?>, value: Expression<V>) {
+    fileprivate init<V : AnyValue>(column: Expression<V?>, value: Expression<V>) {
         self.column = column
         self.value = value
     }
 
-    fileprivate init<V : Value>(column: Expression<V?>, value: Expression<V?>) {
+    fileprivate init<V : AnyValue>(column: Expression<V?>, value: Expression<V?>) {
         self.column = column
         self.value = value
     }
 
-    fileprivate init<V : Value>(column: Expression<V?>, value: V?) {
-        self.column = column
-        self.value = Expression<V?>(value: value)
-    }
-
-    fileprivate init<V : RiskyValue>(column: Expression<V>, value: Expression<V>) {
-        self.column = column
-        self.value = value
-    }
-
-    fileprivate init<V : RiskyValue>(column: Expression<V>, value: V) {
-        self.column = column
-        self.value = value
-    }
-
-    fileprivate init<V : RiskyValue>(column: Expression<V?>, value: Expression<V>) {
-        self.column = column
-        self.value = value
-    }
-
-    fileprivate init<V : RiskyValue>(column: Expression<V?>, value: Expression<V?>) {
-        self.column = column
-        self.value = value
-    }
-
-    fileprivate init<V : RiskyValue>(column: Expression<V?>, value: V?) {
+    fileprivate init<V : AnyValue>(column: Expression<V?>, value: V?) {
         self.column = column
         self.value = Expression<V?>(value: value)
     }
@@ -95,19 +70,19 @@ extension Setter : Expressible {
 
 }
 
-public func <-<V : Value>(column: Expression<V>, value: Expression<V>) -> Setter {
+public func <-<V : AnyValue>(column: Expression<V>, value: Expression<V>) -> Setter {
     return Setter(column: column, value: value)
 }
-public func <-<V : Value>(column: Expression<V>, value: V) -> Setter {
+public func <-<V : AnyValue>(column: Expression<V>, value: V) -> Setter {
     return Setter(column: column, value: value)
 }
-public func <-<V : Value>(column: Expression<V?>, value: Expression<V>) -> Setter {
+public func <-<V : AnyValue>(column: Expression<V?>, value: Expression<V>) -> Setter {
     return Setter(column: column, value: value)
 }
-public func <-<V : Value>(column: Expression<V?>, value: Expression<V?>) -> Setter {
+public func <-<V : AnyValue>(column: Expression<V?>, value: Expression<V?>) -> Setter {
     return Setter(column: column, value: value)
 }
-public func <-<V : Value>(column: Expression<V?>, value: V?) -> Setter {
+public func <-<V : AnyValue>(column: Expression<V?>, value: V?) -> Setter {
     return Setter(column: column, value: value)
 }
 
@@ -127,192 +102,176 @@ public func +=(column: Expression<String?>, value: String) -> Setter {
     return column <- column + value
 }
 
-public func +=<V : Value>(column: Expression<V>, value: Expression<V>) -> Setter where V.Datatype : Number {
+public func +=<V : AnyValue>(column: Expression<V>, value: Expression<V>) -> Setter where V.Datatype : Number {
     return column <- column + value
 }
-public func +=<V : Value>(column: Expression<V>, value: V) -> Setter where V.Datatype : Number {
+public func +=<V : AnyValue>(column: Expression<V>, value: V) -> Setter where V.Datatype : Number {
     return column <- column + value
 }
-public func +=<V : Value>(column: Expression<V?>, value: Expression<V>) -> Setter where V.Datatype : Number {
+public func +=<V : AnyValue>(column: Expression<V?>, value: Expression<V>) -> Setter where V.Datatype : Number {
     return column <- column + value
 }
-public func +=<V : Value>(column: Expression<V?>, value: Expression<V?>) -> Setter where V.Datatype : Number {
+public func +=<V : AnyValue>(column: Expression<V?>, value: Expression<V?>) -> Setter where V.Datatype : Number {
     return column <- column + value
 }
-public func +=<V : Value>(column: Expression<V?>, value: V) -> Setter where V.Datatype : Number {
+public func +=<V : AnyValue>(column: Expression<V?>, value: V) -> Setter where V.Datatype : Number {
     return column <- column + value
 }
 
-public func -=<V : Value>(column: Expression<V>, value: Expression<V>) -> Setter where V.Datatype : Number {
+public func -=<V : AnyValue>(column: Expression<V>, value: Expression<V>) -> Setter where V.Datatype : Number {
     return column <- column - value
 }
-public func -=<V : Value>(column: Expression<V>, value: V) -> Setter where V.Datatype : Number {
+public func -=<V : AnyValue>(column: Expression<V>, value: V) -> Setter where V.Datatype : Number {
     return column <- column - value
 }
-public func -=<V : Value>(column: Expression<V?>, value: Expression<V>) -> Setter where V.Datatype : Number {
+public func -=<V : AnyValue>(column: Expression<V?>, value: Expression<V>) -> Setter where V.Datatype : Number {
     return column <- column - value
 }
-public func -=<V : Value>(column: Expression<V?>, value: Expression<V?>) -> Setter where V.Datatype : Number {
+public func -=<V : AnyValue>(column: Expression<V?>, value: Expression<V?>) -> Setter where V.Datatype : Number {
     return column <- column - value
 }
-public func -=<V : Value>(column: Expression<V?>, value: V) -> Setter where V.Datatype : Number {
+public func -=<V : AnyValue>(column: Expression<V?>, value: V) -> Setter where V.Datatype : Number {
     return column <- column - value
 }
 
-public func *=<V : Value>(column: Expression<V>, value: Expression<V>) -> Setter where V.Datatype : Number {
+public func *=<V : AnyValue>(column: Expression<V>, value: Expression<V>) -> Setter where V.Datatype : Number {
     return column <- column * value
 }
-public func *=<V : Value>(column: Expression<V>, value: V) -> Setter where V.Datatype : Number {
+public func *=<V : AnyValue>(column: Expression<V>, value: V) -> Setter where V.Datatype : Number {
     return column <- column * value
 }
-public func *=<V : Value>(column: Expression<V?>, value: Expression<V>) -> Setter where V.Datatype : Number {
+public func *=<V : AnyValue>(column: Expression<V?>, value: Expression<V>) -> Setter where V.Datatype : Number {
     return column <- column * value
 }
-public func *=<V : Value>(column: Expression<V?>, value: Expression<V?>) -> Setter where V.Datatype : Number {
+public func *=<V : AnyValue>(column: Expression<V?>, value: Expression<V?>) -> Setter where V.Datatype : Number {
     return column <- column * value
 }
-public func *=<V : Value>(column: Expression<V?>, value: V) -> Setter where V.Datatype : Number {
+public func *=<V : AnyValue>(column: Expression<V?>, value: V) -> Setter where V.Datatype : Number {
     return column <- column * value
 }
 
-public func /=<V : Value>(column: Expression<V>, value: Expression<V>) -> Setter where V.Datatype : Number {
+public func /=<V : AnyValue>(column: Expression<V>, value: Expression<V>) -> Setter where V.Datatype : Number {
     return column <- column / value
 }
-public func /=<V : Value>(column: Expression<V>, value: V) -> Setter where V.Datatype : Number {
+public func /=<V : AnyValue>(column: Expression<V>, value: V) -> Setter where V.Datatype : Number {
     return column <- column / value
 }
-public func /=<V : Value>(column: Expression<V?>, value: Expression<V>) -> Setter where V.Datatype : Number {
+public func /=<V : AnyValue>(column: Expression<V?>, value: Expression<V>) -> Setter where V.Datatype : Number {
     return column <- column / value
 }
-public func /=<V : Value>(column: Expression<V?>, value: Expression<V?>) -> Setter where V.Datatype : Number {
+public func /=<V : AnyValue>(column: Expression<V?>, value: Expression<V?>) -> Setter where V.Datatype : Number {
     return column <- column / value
 }
-public func /=<V : Value>(column: Expression<V?>, value: V) -> Setter where V.Datatype : Number {
+public func /=<V : AnyValue>(column: Expression<V?>, value: V) -> Setter where V.Datatype : Number {
     return column <- column / value
 }
 
-public func %=<V : Value>(column: Expression<V>, value: Expression<V>) -> Setter where V.Datatype == Int64 {
+public func %=<V : AnyValue>(column: Expression<V>, value: Expression<V>) -> Setter where V.Datatype == Int64 {
     return column <- column % value
 }
-public func %=<V : Value>(column: Expression<V>, value: V) -> Setter where V.Datatype == Int64 {
+public func %=<V : AnyValue>(column: Expression<V>, value: V) -> Setter where V.Datatype == Int64 {
     return column <- column % value
 }
-public func %=<V : Value>(column: Expression<V?>, value: Expression<V>) -> Setter where V.Datatype == Int64 {
+public func %=<V : AnyValue>(column: Expression<V?>, value: Expression<V>) -> Setter where V.Datatype == Int64 {
     return column <- column % value
 }
-public func %=<V : Value>(column: Expression<V?>, value: Expression<V?>) -> Setter where V.Datatype == Int64 {
+public func %=<V : AnyValue>(column: Expression<V?>, value: Expression<V?>) -> Setter where V.Datatype == Int64 {
     return column <- column % value
 }
-public func %=<V : Value>(column: Expression<V?>, value: V) -> Setter where V.Datatype == Int64 {
+public func %=<V : AnyValue>(column: Expression<V?>, value: V) -> Setter where V.Datatype == Int64 {
     return column <- column % value
 }
 
-public func <<=<V : Value>(column: Expression<V>, value: Expression<V>) -> Setter where V.Datatype == Int64 {
+public func <<=<V : AnyValue>(column: Expression<V>, value: Expression<V>) -> Setter where V.Datatype == Int64 {
     return column <- column << value
 }
-public func <<=<V : Value>(column: Expression<V>, value: V) -> Setter where V.Datatype == Int64 {
+public func <<=<V : AnyValue>(column: Expression<V>, value: V) -> Setter where V.Datatype == Int64 {
     return column <- column << value
 }
-public func <<=<V : Value>(column: Expression<V?>, value: Expression<V>) -> Setter where V.Datatype == Int64 {
+public func <<=<V : AnyValue>(column: Expression<V?>, value: Expression<V>) -> Setter where V.Datatype == Int64 {
     return column <- column << value
 }
-public func <<=<V : Value>(column: Expression<V?>, value: Expression<V?>) -> Setter where V.Datatype == Int64 {
+public func <<=<V : AnyValue>(column: Expression<V?>, value: Expression<V?>) -> Setter where V.Datatype == Int64 {
     return column <- column << value
 }
-public func <<=<V : Value>(column: Expression<V?>, value: V) -> Setter where V.Datatype == Int64 {
+public func <<=<V : AnyValue>(column: Expression<V?>, value: V) -> Setter where V.Datatype == Int64 {
     return column <- column << value
 }
 
-public func >>=<V : Value>(column: Expression<V>, value: Expression<V>) -> Setter where V.Datatype == Int64 {
+public func >>=<V : AnyValue>(column: Expression<V>, value: Expression<V>) -> Setter where V.Datatype == Int64 {
     return column <- column >> value
 }
-public func >>=<V : Value>(column: Expression<V>, value: V) -> Setter where V.Datatype == Int64 {
+public func >>=<V : AnyValue>(column: Expression<V>, value: V) -> Setter where V.Datatype == Int64 {
     return column <- column >> value
 }
-public func >>=<V : Value>(column: Expression<V?>, value: Expression<V>) -> Setter where V.Datatype == Int64 {
+public func >>=<V : AnyValue>(column: Expression<V?>, value: Expression<V>) -> Setter where V.Datatype == Int64 {
     return column <- column >> value
 }
-public func >>=<V : Value>(column: Expression<V?>, value: Expression<V?>) -> Setter where V.Datatype == Int64 {
+public func >>=<V : AnyValue>(column: Expression<V?>, value: Expression<V?>) -> Setter where V.Datatype == Int64 {
     return column <- column >> value
 }
-public func >>=<V : Value>(column: Expression<V?>, value: V) -> Setter where V.Datatype == Int64 {
+public func >>=<V : AnyValue>(column: Expression<V?>, value: V) -> Setter where V.Datatype == Int64 {
     return column <- column >> value
 }
 
-public func &=<V : Value>(column: Expression<V>, value: Expression<V>) -> Setter where V.Datatype == Int64 {
+public func &=<V : AnyValue>(column: Expression<V>, value: Expression<V>) -> Setter where V.Datatype == Int64 {
     return column <- column & value
 }
-public func &=<V : Value>(column: Expression<V>, value: V) -> Setter where V.Datatype == Int64 {
+public func &=<V : AnyValue>(column: Expression<V>, value: V) -> Setter where V.Datatype == Int64 {
     return column <- column & value
 }
-public func &=<V : Value>(column: Expression<V?>, value: Expression<V>) -> Setter where V.Datatype == Int64 {
+public func &=<V : AnyValue>(column: Expression<V?>, value: Expression<V>) -> Setter where V.Datatype == Int64 {
     return column <- column & value
 }
-public func &=<V : Value>(column: Expression<V?>, value: Expression<V?>) -> Setter where V.Datatype == Int64 {
+public func &=<V : AnyValue>(column: Expression<V?>, value: Expression<V?>) -> Setter where V.Datatype == Int64 {
     return column <- column & value
 }
-public func &=<V : Value>(column: Expression<V?>, value: V) -> Setter where V.Datatype == Int64 {
+public func &=<V : AnyValue>(column: Expression<V?>, value: V) -> Setter where V.Datatype == Int64 {
     return column <- column & value
 }
 
-public func |=<V : Value>(column: Expression<V>, value: Expression<V>) -> Setter where V.Datatype == Int64 {
+public func |=<V : AnyValue>(column: Expression<V>, value: Expression<V>) -> Setter where V.Datatype == Int64 {
     return column <- column | value
 }
-public func |=<V : Value>(column: Expression<V>, value: V) -> Setter where V.Datatype == Int64 {
+public func |=<V : AnyValue>(column: Expression<V>, value: V) -> Setter where V.Datatype == Int64 {
     return column <- column | value
 }
-public func |=<V : Value>(column: Expression<V?>, value: Expression<V>) -> Setter where V.Datatype == Int64 {
+public func |=<V : AnyValue>(column: Expression<V?>, value: Expression<V>) -> Setter where V.Datatype == Int64 {
     return column <- column | value
 }
-public func |=<V : Value>(column: Expression<V?>, value: Expression<V?>) -> Setter where V.Datatype == Int64 {
+public func |=<V : AnyValue>(column: Expression<V?>, value: Expression<V?>) -> Setter where V.Datatype == Int64 {
     return column <- column | value
 }
-public func |=<V : Value>(column: Expression<V?>, value: V) -> Setter where V.Datatype == Int64 {
+public func |=<V : AnyValue>(column: Expression<V?>, value: V) -> Setter where V.Datatype == Int64 {
     return column <- column | value
 }
 
-public func ^=<V : Value>(column: Expression<V>, value: Expression<V>) -> Setter where V.Datatype == Int64 {
+public func ^=<V : AnyValue>(column: Expression<V>, value: Expression<V>) -> Setter where V.Datatype == Int64 {
     return column <- column ^ value
 }
-public func ^=<V : Value>(column: Expression<V>, value: V) -> Setter where V.Datatype == Int64 {
+public func ^=<V : AnyValue>(column: Expression<V>, value: V) -> Setter where V.Datatype == Int64 {
     return column <- column ^ value
 }
-public func ^=<V : Value>(column: Expression<V?>, value: Expression<V>) -> Setter where V.Datatype == Int64 {
+public func ^=<V : AnyValue>(column: Expression<V?>, value: Expression<V>) -> Setter where V.Datatype == Int64 {
     return column <- column ^ value
 }
-public func ^=<V : Value>(column: Expression<V?>, value: Expression<V?>) -> Setter where V.Datatype == Int64 {
+public func ^=<V : AnyValue>(column: Expression<V?>, value: Expression<V?>) -> Setter where V.Datatype == Int64 {
     return column <- column ^ value
 }
-public func ^=<V : Value>(column: Expression<V?>, value: V) -> Setter where V.Datatype == Int64 {
+public func ^=<V : AnyValue>(column: Expression<V?>, value: V) -> Setter where V.Datatype == Int64 {
     return column <- column ^ value
 }
 
-public postfix func ++<V : Value>(column: Expression<V>) -> Setter where V.Datatype == Int64 {
+public postfix func ++<V : AnyValue>(column: Expression<V>) -> Setter where V.Datatype == Int64 {
     return Expression<Int>(column) += 1
 }
-public postfix func ++<V : Value>(column: Expression<V?>) -> Setter where V.Datatype == Int64 {
+public postfix func ++<V : AnyValue>(column: Expression<V?>) -> Setter where V.Datatype == Int64 {
     return Expression<Int>(column) += 1
 }
 
-public postfix func --<V : Value>(column: Expression<V>) -> Setter where V.Datatype == Int64 {
+public postfix func --<V : AnyValue>(column: Expression<V>) -> Setter where V.Datatype == Int64 {
     return Expression<Int>(column) -= 1
 }
-public postfix func --<V : Value>(column: Expression<V?>) -> Setter where V.Datatype == Int64 {
+public postfix func --<V : AnyValue>(column: Expression<V?>) -> Setter where V.Datatype == Int64 {
     return Expression<Int>(column) -= 1
-}
-
-public func <-<V : RiskyValue>(column: Expression<V>, value: Expression<V>) -> Setter {
-    return Setter(column: column, value: value)
-}
-public func <-<V : RiskyValue>(column: Expression<V>, value: V) -> Setter {
-    return Setter(column: column, value: value)
-}
-public func <-<V : RiskyValue>(column: Expression<V?>, value: Expression<V>) -> Setter {
-    return Setter(column: column, value: value)
-}
-public func <-<V : RiskyValue>(column: Expression<V?>, value: Expression<V?>) -> Setter {
-    return Setter(column: column, value: value)
-}
-public func <-<V : RiskyValue>(column: Expression<V?>, value: V?) -> Setter {
-    return Setter(column: column, value: value)
 }

--- a/Sources/SQLite/Typed/Setter.swift
+++ b/Sources/SQLite/Typed/Setter.swift
@@ -60,6 +60,31 @@ public struct Setter {
         self.value = Expression<V?>(value: value)
     }
 
+    fileprivate init<V : RiskyValue>(column: Expression<V>, value: Expression<V>) {
+        self.column = column
+        self.value = value
+    }
+
+    fileprivate init<V : RiskyValue>(column: Expression<V>, value: V) {
+        self.column = column
+        self.value = value
+    }
+
+    fileprivate init<V : RiskyValue>(column: Expression<V?>, value: Expression<V>) {
+        self.column = column
+        self.value = value
+    }
+
+    fileprivate init<V : RiskyValue>(column: Expression<V?>, value: Expression<V?>) {
+        self.column = column
+        self.value = value
+    }
+
+    fileprivate init<V : RiskyValue>(column: Expression<V?>, value: V?) {
+        self.column = column
+        self.value = Expression<V?>(value: value)
+    }
+
 }
 
 extension Setter : Expressible {
@@ -274,4 +299,20 @@ public postfix func --<V : Value>(column: Expression<V>) -> Setter where V.Datat
 }
 public postfix func --<V : Value>(column: Expression<V?>) -> Setter where V.Datatype == Int64 {
     return Expression<Int>(column) -= 1
+}
+
+public func <-<V : RiskyValue>(column: Expression<V>, value: Expression<V>) -> Setter {
+    return Setter(column: column, value: value)
+}
+public func <-<V : RiskyValue>(column: Expression<V>, value: V) -> Setter {
+    return Setter(column: column, value: value)
+}
+public func <-<V : RiskyValue>(column: Expression<V?>, value: Expression<V>) -> Setter {
+    return Setter(column: column, value: value)
+}
+public func <-<V : RiskyValue>(column: Expression<V?>, value: Expression<V?>) -> Setter {
+    return Setter(column: column, value: value)
+}
+public func <-<V : RiskyValue>(column: Expression<V?>, value: V?) -> Setter {
+    return Setter(column: column, value: value)
 }

--- a/Tests/SQLiteTests/FoundationTests.swift
+++ b/Tests/SQLiteTests/FoundationTests.swift
@@ -2,7 +2,7 @@ import XCTest
 import SQLite
 
 class FoundationTests : XCTestCase {
-    func testDataFromBlob() {
+    func testDataToBlob() {
         let data = Data([1, 2, 3])
         let blob = data.datatypeValue
         XCTAssertEqual([1, 2, 3], blob.bytes)
@@ -12,5 +12,10 @@ class FoundationTests : XCTestCase {
         let blob = Blob(bytes: [1, 2, 3])
         let data = Data.fromDatatypeValue(blob)
         XCTAssertEqual(Data([1, 2, 3]), data)
+    }
+
+    func testStringToURL() throws {
+        XCTAssertThrowsError(try URL.fromDatatypeValue(""))
+        XCTAssertEqual(URL(string: "/")!, try URL.fromDatatypeValue("/"))
     }
 }


### PR DESCRIPTION
## Synopsis

The `Value` type is re-based on `AnyValue` that can fail and throw in `fromDatatypeValue(_:)` aka restoring a Swift datatype from SQLite column data. `Value` then adds its usual non-throwing method as a convenience. 

Then, `RiskyValue` is introduced that does only have the throwing variant. The intended use:

- `Value` for non-throwing, simple datatypes
- `RiskyValue` for throwing, failable datatypes, like `Foundation.URL`

The common `AnyValue` base helps with the introduction of `RiskyValue` in the SQLite code base. Without a common ancestor, we'd have to duplicate a lot of the implementation code.

I admit that `RiskyValue` now doesn't add a lot of implementation -- it is mostly there so we don't base our URL wrapper on the "abstract" base type. I prefer to pretend that it doesn't exist in client code:

```
      ┌ ─ ─ ─ ─ ─ ┐
        AnyValue                   <<< ignore this
      └ ─ ─ ─ ─ ─ ┘
            ▲
     ┌──────┴─────────┐
     │                │
╔════════╗     ╔════════════╗
║ Value  ║     ║ RiskyValue ║        <<< use these
╚════════╝     ╚════════════╝
```

These changes make the latest PR to Timing possible.

Still a WIP for us to discuss.

(All tests pass.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mrmage/sqlite.swift/3)
<!-- Reviewable:end -->
