### PR TITLE
Change (NS)Date to store its value as unix epoch

### DIFF
--- a/Sources/SQLite/Foundation.swift
+++ b/Sources/SQLite/Foundation.swift
@@ -48,10 +48,12 @@ extension Date : SafeValue {
         return Double.declaredDatatype
     }
 
+    /// - Parameter doubleValue: Time interval since 1970 (Unix Epoch).
     public static func fromDatatypeValue(_ doubleValue: Double) -> Date {
         return Date(timeIntervalSince1970: doubleValue)
     }
 
+    /// Time interval since 1970 (Unix Epoch).
     public var datatypeValue: Double {
         return timeIntervalSince1970
     }

--- a/Sources/SQLite/Foundation.swift
+++ b/Sources/SQLite/Foundation.swift
@@ -45,15 +45,15 @@ extension Data : SafeValue {
 extension Date : SafeValue {
 
     public static var declaredDatatype: String {
-        return String.declaredDatatype
+        return Double.declaredDatatype
     }
 
-    public static func fromDatatypeValue(_ stringValue: String) -> Date {
-        return dateFormatter.date(from: stringValue)!
+    public static func fromDatatypeValue(_ doubleValue: Double) -> Date {
+        return Date(timeIntervalSince1970: doubleValue)
     }
 
-    public var datatypeValue: String {
-        return dateFormatter.string(from: self)
+    public var datatypeValue: Double {
+        return timeIntervalSince1970
     }
 
 }

--- a/Sources/SQLite/Foundation.swift
+++ b/Sources/SQLite/Foundation.swift
@@ -58,17 +58,6 @@ extension Date : SafeValue {
 
 }
 
-/// A global date formatter used to serialize and deserialize `NSDate` objects.
-/// If multiple date formats are used in an application’s database(s), use a
-/// custom `Value` type per additional format.
-public var dateFormatter: DateFormatter = {
-    let formatter = DateFormatter()
-    formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS"
-    formatter.locale = Locale(identifier: "en_US_POSIX")
-    formatter.timeZone = TimeZone(secondsFromGMT: 0)
-    return formatter
-}()
-
 extension URL : RiskyValue {
     
     public enum URLRiskyValueError: Error {

--- a/Sources/SQLite/Typed/DateAndTimeFunctions.swift
+++ b/Sources/SQLite/Typed/DateAndTimeFunctions.swift
@@ -87,6 +87,17 @@ extension Date {
     }
 }
 
+/// A global date formatter used to serialize and deserialize `NSDate` objects.
+/// If multiple date formats are used in an application’s database(s), use a
+/// custom `Value` type per additional format.
+public var dateFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS"
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = TimeZone(secondsFromGMT: 0)
+    return formatter
+}()
+
 extension Expression where UnderlyingType == Date {
     public var date: Expression<Date> {
         return Expression<Date>("date(\(template))", bindings)

--- a/Sources/SQLite/Typed/DateAndTimeFunctions.swift
+++ b/Sources/SQLite/Typed/DateAndTimeFunctions.swift
@@ -100,18 +100,18 @@ public var dateFormatter: DateFormatter = {
 
 extension Expression where UnderlyingType == Date {
     public var date: Expression<Date> {
-        return Expression<Date>("date(\(template))", bindings)
+        return Expression<Date>("date(\(template), 'unixepoch')", bindings)
     }
 
     public var time: Expression<Date> {
-        return Expression<Date>("time(\(template))", bindings)
+        return Expression<Date>("time(\(template), 'unixepoch')", bindings)
     }
 
     public var datetime: Expression<Date> {
-        return Expression<Date>("datetime(\(template))", bindings)
+        return Expression<Date>("datetime(\(template), 'unixepoch')", bindings)
     }
 
     public var julianday: Expression<Date> {
-        return Expression<Date>("julianday(\(template))", bindings)
+        return Expression<Date>("julianday(\(template), 'unixepoch')", bindings)
     }
 }

--- a/Tests/SQLiteTests/DateAndTimeFunctionTests.swift
+++ b/Tests/SQLiteTests/DateAndTimeFunctionTests.swift
@@ -49,18 +49,18 @@ class DateExtensionTests : XCTestCase {
 
 class DateExpressionTests : XCTestCase {
     func test_date() {
-        AssertSQL("date(\"date\")", date.date)
+        AssertSQL("date(\"date\", 'unixepoch')", date.date)
     }
 
     func test_time() {
-        AssertSQL("time(\"date\")", date.time)
+        AssertSQL("time(\"date\", 'unixepoch')", date.time)
     }
 
     func test_datetime() {
-        AssertSQL("datetime(\"date\")", date.datetime)
+        AssertSQL("datetime(\"date\", 'unixepoch')", date.datetime)
     }
 
     func test_julianday() {
-        AssertSQL("julianday(\"date\")", date.julianday)
+        AssertSQL("julianday(\"date\", 'unixepoch')", date.julianday)
     }
 }

--- a/Tests/SQLiteTests/OperatorsTests.swift
+++ b/Tests/SQLiteTests/OperatorsTests.swift
@@ -304,17 +304,17 @@ class OperatorsTests : XCTestCase {
 
     func test_dateExpressionLessGreater() {
         let begin = Date(timeIntervalSince1970: 0)
-        AssertSQL("(\"date\" < '1970-01-01T00:00:00.000')", date < begin)
-        AssertSQL("(\"date\" > '1970-01-01T00:00:00.000')", date > begin)
-        AssertSQL("(\"date\" >= '1970-01-01T00:00:00.000')", date >= begin)
-        AssertSQL("(\"date\" <= '1970-01-01T00:00:00.000')", date <= begin)
+        AssertSQL("(\"date\" < 0.0)", date < begin)
+        AssertSQL("(\"date\" > 0.0)", date > begin)
+        AssertSQL("(\"date\" >= 0.0)", date >= begin)
+        AssertSQL("(\"date\" <= 0.0)", date <= begin)
     }
 
     func test_dateExpressionRange() {
         let begin = Date(timeIntervalSince1970: 0)
         let end = Date(timeIntervalSince1970: 5000)
         AssertSQL(
-            "\"date\" >= '1970-01-01T00:00:00.000' AND \"date\" < '1970-01-01T01:23:20.000'",
+            "\"date\" >= 0.0 AND \"date\" < 5000.0",
             (begin..<end) ~= date
         )
     }
@@ -323,7 +323,7 @@ class OperatorsTests : XCTestCase {
         let begin = Date(timeIntervalSince1970: 0)
         let end = Date(timeIntervalSince1970: 5000)
         AssertSQL(
-            "\"date\" BETWEEN '1970-01-01T00:00:00.000' AND '1970-01-01T01:23:20.000'",
+            "\"date\" BETWEEN 0.0 AND 5000.0",
             (begin...end) ~= date
         )
     }


### PR DESCRIPTION
In the end, I decided to skip porting the DateAndTimeFunctions. The queries they generate, as per the [SQLite docs](https://www.sqlite.org/lang_datefunc.html), work independently from column values:

     SELECT date('now','start of month','+1 month','-1 day'); 
     SELECT strftime('%s','now') - strftime('%s','2004-01-01 02:34:56'); 

Of course there you can also use the 'unixepoch' modifier and pass in double values, but these are queries for time from the DB. I think it's fine to keep these.

I did adjust column-bases `Expression<Date>` modifiers to append the  'unixepoch' modifier. I believe that's what we want. 

To be honest, I'm only 90% certain about this. Since we apparently use neither of the functions in the app, the Date-as-Double storage is the only thing that I can verify in Timing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mrmage/sqlite.swift/5)
<!-- Reviewable:end -->
