### PR TITLE
TR-4646: Rename the SQLite module to SQLiteSwift

### DIFF
--- a/SQLite.swift.podspec
+++ b/SQLite.swift.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/stephencelis/SQLite.swift.git", :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/stephencelis'
 
-  s.module_name      = 'SQLite'
+  s.module_name      = 'SQLiteSwift'
   s.default_subspec  = 'standard'
   s.swift_versions = ['5']
 


### PR DESCRIPTION
### The SQLite runtime problem
```
objc[19519]: Class _TtC6SQLite6Backup is implemented in both /System/Library/PrivateFrameworks/LinkServices.framework/Versions/A/LinkServices (0x284f9aa98) and /Users/daniel/Library/Developer/Xcode/DerivedData/Timing-gwejlirkuhrpekbskcnoxlteftaf/Build/Products/Debug/Timing.app/Contents/Frameworks/SQLite.framework/Versions/A/SQLite (0x104b01ce0). One of the two will be used. Which one is undefined.
```
has been reported on Dec 8, 2022 and is still open with last comment on Sep 29, 2024 (`No update?`)
https://github.com/stephencelis/SQLite.swift/issues/1177

also has been duplicated by these
https://github.com/stephencelis/SQLite.swift/issues/1201
https://github.com/stephencelis/SQLite.swift/issues/1226

There does not seem to be other solution then changing module_name in `SQLite.swift.podspec` file to for example
`s.module_name = 'SQLiteSwift'` or any name we choose.
Then instead of `import SQLite` we have to use `import SQLiteSwift`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Timing-GmbH/SQLite.swift/6)
<!-- Reviewable:end -->
