### PR TITLE
TR-4656: Replace `ResultOrError` with `Swift.Result`

### DIFF
--- a/Sources/SQLite/Core/Statement.swift
+++ b/Sources/SQLite/Core/Statement.swift
@@ -205,42 +205,22 @@ extension Statement: Sequence {
         reset(clearBindings: false)
         return self
     }
-
 }
 
-public enum ResultOrError<ResultType> {
-    case success(ResultType)
-    case error(Error)
-    
-    public func map<T>(_ transform: (ResultType) throws -> T) rethrows -> ResultOrError<T> {
-        switch self {
-        case let .success(result): return try .success(transform(result))
-        case let .error(error): return .error(error)
-        }
-    }
-    
-    public func unwrapOrThrow() throws -> ResultType {
-        switch self {
-        case let .success(result): return result
-        case let .error(error): throw error
-        }
-    }
-}
-
-public protocol FailableIterator : IteratorProtocol where Element == ResultOrError<WrappedElement> {
+public protocol FailableIterator : IteratorProtocol where Element == Swift.Result<WrappedElement, Error> {
     associatedtype WrappedElement
     
     func failableNext() throws -> WrappedElement?
 }
 
 extension FailableIterator {
-    public func next() -> ResultOrError<WrappedElement>? {
+	public func next() -> Swift.Result<WrappedElement, Error>? {
         do {
             guard let nextRow = try failableNext()
                 else { return nil }
             return .success(nextRow)
         } catch {
-            return .error(error)
+            return .failure(error)
         }
     }
 }

--- a/Sources/SQLite/Schema/Connection+Schema.swift
+++ b/Sources/SQLite/Schema/Connection+Schema.swift
@@ -14,8 +14,8 @@ public extension Connection {
     // https://sqlite.org/pragma.html#pragma_foreign_key_check
     func foreignKeyCheck(table: String? = nil) throws -> [ForeignKeyError] {
         try run("PRAGMA foreign_key_check" + (table.map { "(\($0.quote()))" } ?? ""))
-			.compactMap { (wrappedRow: ResultOrError<[Binding?]>) -> ForeignKeyError? in
-				let row = try wrappedRow.unwrapOrThrow()
+			.compactMap { (wrappedRow: Swift.Result<[Binding?], Error>) -> ForeignKeyError? in
+				let row = try wrappedRow.get()
                 guard let table = row[0] as? String,
                       let rowId = row[1] as? Int64,
                       let target = row[2] as? String else { return nil }
@@ -30,7 +30,7 @@ public extension Connection {
         precondition(table == nil || supports(.partialIntegrityCheck), "partial integrity check not supported")
 
         return try run("PRAGMA integrity_check" + (table.map { "(\($0.quote()))" } ?? ""))
-			.compactMap { try $0.unwrapOrThrow()[0] as? String }
+			.compactMap { try $0.get()[0] as? String }
             .filter { $0 != "ok" }
     }
 }

--- a/Sources/SQLite/Schema/SchemaReader.swift
+++ b/Sources/SQLite/Schema/SchemaReader.swift
@@ -46,7 +46,7 @@ public class SchemaReader {
             query = query.where(SchemaTable.typeColumn == type.rawValue)
         }
         return try connection.prepare(query).map { wrappedRow -> ObjectDefinition in
-			let row = try wrappedRow.unwrapOrThrow()
+			let row = try wrappedRow.get()
 			guard let type = ObjectDefinition.ObjectType(rawValue: row[SchemaTable.typeColumn]) else {
                 fatalError("unexpected type")
             }

--- a/Sources/SQLite/Typed/Query.swift
+++ b/Sources/SQLite/Typed/Query.swift
@@ -1003,7 +1003,7 @@ public struct RowIterator: FailableIterator {
 
 extension Connection {
 
-    public func prepare(_ query: QueryType) throws -> AnySequence<ResultOrError<Row>> {
+	public func prepare(_ query: QueryType) throws -> AnySequence<Swift.Result<Row, Error>> {
         let expression = query.expression
         let statement = try prepare(expression.template, expression.bindings)
 


### PR DESCRIPTION
- removed `ResultOrError` and replaces with `Swift.Result`
- consuming client needs to change all instances of `unwrapOrThrow()` to `get()`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Timing-GmbH/SQLite.swift/8)
<!-- Reviewable:end -->
