### PR TITLE
Rename Swift lib to SQLiteSwift & use standalone CSQLite on macOS, too

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,13 +12,14 @@ let package = Package(
     ],
     products: [
         .library(
-            name: "SQLite",
-            targets: ["SQLite"]
+            name: "SQLiteSwift",
+            targets: ["SQLiteSwift"]
         )
     ],
     targets: [
         .target(
-            name: "SQLite",
+            name: "SQLiteSwift",
+            path: "Sources/SQLite",
             exclude: [
                 "Info.plist"
             ]
@@ -26,7 +27,7 @@ let package = Package(
         .testTarget(
             name: "SQLiteTests",
             dependencies: [
-                "SQLite"
+                "SQLiteSwift"
             ],
             path: "Tests/SQLiteTests",
             exclude: [
@@ -39,11 +40,11 @@ let package = Package(
     ]
 )
 
-#if os(Linux) || os(Windows) || os(Android)
+// Use CSQLite on all platforms to ensure consistent SQLite configuration
+// (especially SQLITE_MAX_VARIABLE_NUMBER for Timing's long filter queries)
 package.dependencies = [
-    .package(url: "https://github.com/Timing-GmbH/CSQLite", branch: "main")
+    .package(url: "https://github.com/Jeehut/CSQLite", branch: "main")
 ]
 package.targets.first?.dependencies += [
     .product(name: "CSQLite", package: "CSQLite")
 ]
-#endif

--- a/Package.swift
+++ b/Package.swift
@@ -43,7 +43,7 @@ let package = Package(
 // Use CSQLite on all platforms to ensure consistent SQLite configuration
 // (especially SQLITE_MAX_VARIABLE_NUMBER for Timing's long filter queries)
 package.dependencies = [
-    .package(url: "https://github.com/Jeehut/CSQLite", branch: "main")
+    .package(url: "https://github.com/Timing-GmbH/CSQLite", branch: "macos")
 ]
 package.targets.first?.dependencies += [
     .product(name: "CSQLite", package: "CSQLite")

--- a/Sources/SQLite/Core/Backup.swift
+++ b/Sources/SQLite/Core/Backup.swift
@@ -28,10 +28,8 @@ import Dispatch
 import sqlite3
 #elseif SQLITE_SWIFT_SQLCIPHER
 import SQLCipher
-#elseif os(Linux) || os(Windows) || os(Android)
-import CSQLite
 #else
-import SQLite3
+import CSQLite
 #endif
 
 /// An object representing database backup.

--- a/Sources/SQLite/Core/Connection+Aggregation.swift
+++ b/Sources/SQLite/Core/Connection+Aggregation.swift
@@ -3,10 +3,8 @@ import Foundation
 import sqlite3
 #elseif SQLITE_SWIFT_SQLCIPHER
 import SQLCipher
-#elseif os(Linux) || os(Windows) || os(Android)
-import CSQLite
 #else
-import SQLite3
+import CSQLite
 #endif
 
 extension Connection {

--- a/Sources/SQLite/Core/Connection+Attach.swift
+++ b/Sources/SQLite/Core/Connection+Attach.swift
@@ -3,10 +3,8 @@ import Foundation
 import sqlite3
 #elseif SQLITE_SWIFT_SQLCIPHER
 import SQLCipher
-#elseif os(Linux) || os(Windows) || os(Android)
-import CSQLite
 #else
-import SQLite3
+import CSQLite
 #endif
 
 extension Connection {

--- a/Sources/SQLite/Core/Connection.swift
+++ b/Sources/SQLite/Core/Connection.swift
@@ -28,10 +28,8 @@ import Dispatch
 import sqlite3
 #elseif SQLITE_SWIFT_SQLCIPHER
 import SQLCipher
-#elseif os(Linux) || os(Windows) || os(Android)
-import CSQLite
 #else
-import SQLite3
+import CSQLite
 #endif
 
 /// A connection to SQLite.

--- a/Sources/SQLite/Core/Result.swift
+++ b/Sources/SQLite/Core/Result.swift
@@ -2,10 +2,8 @@
 import sqlite3
 #elseif SQLITE_SWIFT_SQLCIPHER
 import SQLCipher
-#elseif os(Linux) || os(Windows) || os(Android)
-import CSQLite
 #else
-import SQLite3
+import CSQLite
 #endif
 
 public enum Result: Error {

--- a/Sources/SQLite/Core/Statement.swift
+++ b/Sources/SQLite/Core/Statement.swift
@@ -26,10 +26,8 @@
 import sqlite3
 #elseif SQLITE_SWIFT_SQLCIPHER
 import SQLCipher
-#elseif os(Linux) || os(Windows) || os(Android)
-import CSQLite
 #else
-import SQLite3
+import CSQLite
 #endif
 
 /// A single SQL statement.

--- a/Sources/SQLite/Helpers.swift
+++ b/Sources/SQLite/Helpers.swift
@@ -26,10 +26,8 @@
 import sqlite3
 #elseif SQLITE_SWIFT_SQLCIPHER
 import SQLCipher
-#elseif os(Linux) || os(Windows) || os(Android)
-import CSQLite
 #else
-import SQLite3
+import CSQLite
 #endif
 
 public typealias Star = (Expression<Binding>?, Expression<Binding>?) -> Expression<Void>


### PR DESCRIPTION
Previously CSQLite was only used on Linux/Windows/Android, and macOS used the system SQLite library. This caused issues when migrating from CocoaPods because:

- CocoaPods: SQLite.swift → custom sqlite3 pod (with Timing-specific flags)
- SPM (old): SQLite.swift → system SQLite (no custom flags!)

Now using CSQLite on all platforms ensures we get the same compiler flags (especially `SQLITE_MAX_VARIABLE_NUMBER=200000000`) that were configured in the CocoaPods setup.

Changes:
- Package.swift: Added CSQLite dependency for all platforms (not just Linux/Windows/Android)
- Source files: Updated import statements to use CSQLite instead of system SQLite3

References Jeehut/CSQLite main branch which includes:
- `SQLITE_MAX_VARIABLE_NUMBER=200000000`
- `SQLITE_DEFAULT_PAGE_SIZE=4096`

I also renamed the lib to `SQLiteSwift` to match the previous CocoaPods renaming (see #6).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Timing-GmbH/SQLite.swift/9)
<!-- Reviewable:end -->
